### PR TITLE
Support http-basic-auth via basicAuth setting

### DIFF
--- a/lib/wordpress.js
+++ b/lib/wordpress.js
@@ -44,6 +44,10 @@ function Client( settings ) {
 		// via settings.host
 		headers: {
 			Host: parsedUrl.host
+		},
+		basic_auth: !settings.basicAuth ? null : {
+			user: settings.basicAuth.username,
+			pass: settings.basicAuth.password
 		}
 	});
 	this.blogId = settings.blogId || 0;

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,9 @@ Creates a new client instance.
   * `host` (optional): The actual host to connect to if different from the URL, e.g., when deploying to a local server behind a firewall.
   * `blogId` (optional; default: `0`): The blog ID for the WordPress install.
   * `rejectUnauthorized` (optional; default: `true`): A boolean indicating whether Node.js should automatically reject clients with invalid certificates. See [tls.createSecurePair()](https://nodejs.org/api/tls.html#tls_tls_createsecurepair_context_isserver_requestcert_rejectunauthorized_options) in Node's documentation.
-
+  * `basicAuth` (optional: default: `null`): A object holding http basic authentication credentials
+    * `username`: The username for the http basic auth.
+    * `password`: The password for the http basic auth.
 #### wordpress.Client
 
 The constructor used for client connections. Useful for creating extensions.


### PR DESCRIPTION
use settings.basicAuth.username and settings.basicAuth.password to
configure basic authentication.