### PR TITLE
wordpress: use host for SNI if applicable

### DIFF
--- a/lib/wordpress.js
+++ b/lib/wordpress.js
@@ -39,6 +39,7 @@ function Client( settings ) {
 		port: parsedUrl.port,
 		path: parsedUrl.path,
 		rejectUnauthorized: settings.rejectUnauthorized !== undefined ? settings.rejectUnauthorized : true,
+		servername: settings.host || parsedUrl.host,
 
 		// Always set Host header in case we're pointing to a different server
 		// via settings.host


### PR DESCRIPTION
When `host` is configured, use that for the TLS connection SNI and hostname validation too instead of the host parsed from the URL.